### PR TITLE
🐛 Fix:  크로스 도메인 환경에서 Refresh 쿠키 미전송 문제 수정

### DIFF
--- a/src/main/java/com/coduk/duksungmap/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/coduk/duksungmap/domain/auth/service/RefreshTokenService.java
@@ -9,6 +9,8 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -100,25 +102,29 @@ public class RefreshTokenService {
             throw new CustomException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND);
         }
 
-        Cookie cookie = new Cookie(refreshCookieName, refreshTokenRaw);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(cookieSecure); // 로컬 false, 배포 https true
-        cookie.setPath("/");
-
         long seconds = refreshTtlDays * 24L * 60L * 60L;
-        int maxAge = seconds > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) seconds;
-        cookie.setMaxAge(maxAge);
 
-        response.addCookie(cookie);
+        ResponseCookie cookie = ResponseCookie.from(refreshCookieName, refreshTokenRaw)
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .path("/")
+                .maxAge(seconds)
+                .sameSite(cookieSecure ? "None" : "Lax") // prod는 None, local은 Lax
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
     public void clearRefreshCookie(HttpServletResponse response) {
-        Cookie cookie = new Cookie(refreshCookieName, "");
-        cookie.setHttpOnly(true);
-        cookie.setSecure(cookieSecure);
-        cookie.setPath("/");
-        cookie.setMaxAge(0);
-        response.addCookie(cookie);
+        ResponseCookie cookie = ResponseCookie.from(refreshCookieName, "")
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .path("/")
+                .maxAge(0)
+                .sameSite(cookieSecure ? "None" : "Lax")
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
     // 재발급/검증에서 사용


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- ResponseCookie 방식으로 변경
- SameSite=None 적용 (배포 환경)
- 크로스 도메인 환경에서 refresh 쿠키 정상 전송되도록 수정

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #23 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [x] 기능 구현
- [ ] 코드 리뷰 반영

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->
