### PR TITLE
🐛 Fix: refresh_token 쿠키를 서브도메인 공용으로 설정

### DIFF
--- a/src/main/java/com/coduk/duksungmap/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/coduk/duksungmap/domain/auth/service/RefreshTokenService.java
@@ -5,7 +5,6 @@ import com.coduk.duksungmap.domain.auth.exception.AuthErrorCode;
 import com.coduk.duksungmap.domain.auth.repository.RefreshTokenRepository;
 import com.coduk.duksungmap.domain.user.entity.User;
 import com.coduk.duksungmap.global.exception.CustomException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -110,6 +109,7 @@ public class RefreshTokenService {
                 .path("/")
                 .maxAge(seconds)
                 .sameSite(cookieSecure ? "None" : "Lax") // prod는 None, local은 Lax
+                .domain(".duksung-map.site")
                 .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
@@ -122,6 +122,7 @@ public class RefreshTokenService {
                 .path("/")
                 .maxAge(0)
                 .sameSite(cookieSecure ? "None" : "Lax")
+                .domain(".duksung-map.site")
                 .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- 도메인 설정 (`.duksung-map.site`)

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #23 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [x] 기능 구현
- [ ] 코드 리뷰 반영

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->
