### PR TITLE
[Bugfix] 이메일 인증 메일 로고 이미지 렌더링 문제 수정

### DIFF
--- a/src/main/java/com/coduk/duksungmap/domain/auth/service/EmailService.java
+++ b/src/main/java/com/coduk/duksungmap/domain/auth/service/EmailService.java
@@ -26,13 +26,6 @@ public class EmailService {
     @Value("${app.mail.logo-path:static/images/logo.png}")
     private String logoPath;
 
-    private String logoBase64;
-
-    @PostConstruct
-    void initLogo() {
-        this.logoBase64 = loadBase64OrEmpty(logoPath);
-    }
-
     public void send(String to, String code) {
         MimeMessage message = mailSender.createMimeMessage();
 
@@ -43,7 +36,12 @@ public class EmailService {
             helper.setTo(to);
             helper.setSubject("[덕성여대 지도 서비스] 이메일 인증 번호 안내");
             helper.setFrom(fromEmail);
-            helper.setText(buildBody(code, logoBase64), true);
+            helper.setText(buildBody(code), true);
+
+            ClassPathResource logo = new ClassPathResource(logoPath);
+            if (logo.exists()) {
+                helper.addInline("logo", logo, "image/png");
+            }
 
             mailSender.send(message);
 
@@ -52,31 +50,14 @@ public class EmailService {
         }
     }
 
-    private String loadBase64OrEmpty(String classpathLocation) {
-        try {
-            ClassPathResource resource = new ClassPathResource(classpathLocation);
-            if (!resource.exists()) return "";
-            try (InputStream in = resource.getInputStream()) {
-                byte[] bytes = in.readAllBytes();
-                return Base64.getEncoder().encodeToString(bytes);
-            }
-        } catch (Exception e) {
-            // 로고 못 읽어도 메일은 보내짐
-            return "";
-        }
-    }
-
-    private String buildBody(String code, String logoBase64) {
-        // logoBase64가 비면 <img> 자체를 렌더링 안 하게 처리 (깨짐 방지)
-        String logoHtml = (logoBase64 == null || logoBase64.isBlank())
-                ? ""
-                : """
+    private String buildBody(String code) {
+        String logoHtml = """
                    <img class="logo"
-                        src="data:image/png;base64,%s"
+                        src="cid:logo"
                         width="90"
                         alt="덕성여대 지도 서비스"
                         style="display:block; margin-left:45px; margin-bottom:40px;" />
-                   """.formatted(logoBase64);
+                   """;
 
         return """
     <!doctype html>

--- a/src/main/java/com/coduk/duksungmap/domain/auth/service/EmailService.java
+++ b/src/main/java/com/coduk/duksungmap/domain/auth/service/EmailService.java
@@ -33,13 +33,15 @@ public class EmailService {
             MimeMessageHelper helper =
                     new MimeMessageHelper(message, true, "UTF-8");
 
+            ClassPathResource logo = new ClassPathResource(logoPath);
+            boolean hasLogo = logo.exists();
+
             helper.setTo(to);
             helper.setSubject("[덕성여대 지도 서비스] 이메일 인증 번호 안내");
             helper.setFrom(fromEmail);
-            helper.setText(buildBody(code), true);
+            helper.setText(buildBody(code, hasLogo), true);
 
-            ClassPathResource logo = new ClassPathResource(logoPath);
-            if (logo.exists()) {
+            if (hasLogo) {
                 helper.addInline("logo", logo, "image/png");
             }
 
@@ -50,14 +52,11 @@ public class EmailService {
         }
     }
 
-    private String buildBody(String code) {
-        String logoHtml = """
-                   <img class="logo"
-                        src="cid:logo"
-                        width="90"
-                        alt="덕성여대 지도 서비스"
-                        style="display:block; margin-left:45px; margin-bottom:40px;" />
-                   """;
+    private String buildBody(String code, boolean hasLogo) {
+        String logoHtml = hasLogo ? """
+        <img src="cid:logo" width="90" alt="덕성여대 지도 서비스"
+             style="display:block; margin-left:45px; margin-bottom:40px;" />
+        """ : "";
 
         return """
     <!doctype html>


### PR DESCRIPTION
## 📄 작업 내용 요약
<!-- 무엇을 작업했는지 간단하게 요약해주세요 -->

- 이메일 인증 메일에서 로고 이미지를 Base64(Data URI) 방식으로 삽입하던 구조를 CID inline 방식으로 변경
- 로고 리소스가 존재하지 않는 경우 <img> 태그가 렌더링되지 않도록 조건부 렌더링(hasLogo) 로직을 추가

---

## 📎 Issue 번호
<!-- 관련된 이슈가 있다면 닫히도록 연결해주세요 (ex: closed #1) -->

- closed #32 

---

## ✅ 작업 목록
<!-- 체크박스로 완료한 작업을 표시해주세요 -->

- [x] 기능 구현
- [ ] 코드 리뷰 반영

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->
